### PR TITLE
fix: change agent_custom_config column type to TEXT to prevent Data too long error

### DIFF
--- a/api/model/message.go
+++ b/api/model/message.go
@@ -21,7 +21,7 @@ type Message struct {
 	ElapsedTime       int64  `json:"elapsed_time" gorm:"default:0"`
 	IsStream          bool   `json:"is_stream" gorm:"default:false"`
 	QuotaContent      string `json:"quota_content" gorm:"default:''"`
-	AgentCustomConfig string `json:"agent_custom_config" gorm:"default:''"`
+	AgentCustomConfig string `json:"agent_custom_config" gorm:"default:'';type:text"`
 	BaseModel
 }
 


### PR DESCRIPTION
Fixes #52
Fixes #57

## Problem

The agent_custom_config column in the messages table was created without an explicit type annotation in its GORM struct tag. This caused GORM to use a short VARCHAR type (reported as VARCHAR(16) or VARCHAR(255) depending on setup), insufficient for storing longer agent configuration content.

Users encountered: Error 1406 (22001): Data too long for column 'agent_custom_config' at row 1

## Solution

Added type:text to the GORM tag for AgentCustomConfig in api/model/message.go, consistent with how Message, Answer, and ReasoningContent are defined in the same struct.

Before: AgentCustomConfig string with gorm:"default:''"
After:  AgentCustomConfig string with gorm:"default:'';type:text"

When MIGRATE_DB_ENABLED=true, AutoMigrate will update the column type in existing databases.

## Testing

Verified the fix is minimal and consistent with other long-text fields in the struct.