### PR TITLE
fix: repair broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Refer to the comments in `.env.example`, copy and rename it to `.env`, and edit 
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=53AI/53AIhub&type=Date)](https://star-history.com/#53AI/53AIhub&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=53AI/53AIhub&type=Date)](https://star-history.dera.page/#53AI/53AIhub&Date)
 
 
 ## Contributing

--- a/README_CN.md
+++ b/README_CN.md
@@ -171,7 +171,7 @@ docker compose up -d
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=53AI/53AIhub&type=Date)](https://star-history.com/#53AI/53AIhub&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=53AI/53AIhub&type=Date)](https://star-history.dera.page/#53AI/53AIhub&Date)
 
 ## 参与项目
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -96,7 +96,7 @@ docker compose up -d
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=53AI/53AIhub&type=Date)](https://star-history.com/#53AI/53AIhub&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=53AI/53AIhub&type=Date)](https://star-history.dera.page/#53AI/53AIhub&Date)
 
 
 ## コミュニティへの参加


### PR DESCRIPTION
The star history chart currently displayed in our READMEs is broken and no longer renders. This change updates the chart links and image sources across the English, Chinese, and Japanese READMEs so the chart works again. No API token is required, and the chart keeps its original daily view for 53AI/53AIhub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History chart images and links in the English, Chinese, and Japanese README files.
  * References now use the new Star History domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->